### PR TITLE
fix spawn on windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: ExtensionContext) {
   const command: string = extensionConfig.get("path") || "";
   const debugChannel = window.createOutputChannel(baseName + ' Server');
   const serverOptions: ServerOptions = () => new Promise<StreamInfo>((resolve, reject) => {
-    const serverProcess = spawn(command, [], { cwd: rootPath() });
+    const serverProcess = spawn(command, [], { cwd: rootPath(), shell: true });
     if (!serverProcess || !serverProcess.pid) {
       return reject(`Launching server using command ${command} failed.`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import {
 } from 'vscode-languageclient/node';
 
 import { Readable } from 'stream';
+import process = require('process')
 
 const baseName = 'Idris 2 LSP';
 
@@ -27,7 +28,7 @@ export function activate(context: ExtensionContext) {
   const command: string = extensionConfig.get("path") || "";
   const debugChannel = window.createOutputChannel(baseName + ' Server');
   const serverOptions: ServerOptions = () => new Promise<StreamInfo>((resolve, reject) => {
-    const serverProcess = spawn(command, [], { cwd: rootPath(), shell: true });
+    const serverProcess = spawn(command, [], { cwd: rootPath(), shell: process.platform === 'win32' });
     if (!serverProcess || !serverProcess.pid) {
       return reject(`Launching server using command ${command} failed.`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import {
 } from 'vscode-languageclient/node';
 
 import { Readable } from 'stream';
-import process = require('process')
+import * as process from 'process'
 
 const baseName = 'Idris 2 LSP';
 


### PR DESCRIPTION
I get the error on windows: `Couldn't start client Idris 2 LSP Client`.
I checked the code and found out that it was a problem with the `spawn` function.
This is a common problem, can refer to this [link](https://stackoverflow.com/questions/18334181/spawn-on-node-js-windows-server-2012).
Using `shell:true` can solve this problem, or a [library](https://www.npmjs.com/package/cross-spawn) such as this one.

Here is my modification, now it works fine on my windows.