### PR TITLE
Add option to use brief completions (without args)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
 					"default": false,
 					"definition": "Show full namespace in hovers"
 				},
+				"idris2-lsp.briefCompletions": {
+					"type": "boolean",
+					"default": false,
+					"definition": "Insert function name without arguments when completing."
+				},
 				"idris2-lsp.trace.server": {
 					"scope": "window",
 					"type": "string",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 				},
 				"idris2-lsp.briefCompletions": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"definition": "Insert function name without arguments when completing."
 				},
 				"idris2-lsp.trace.server": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ export function activate(context: ExtensionContext) {
     showImplicits: extensionConfig.get("showImplicits") || false,
     showMachineNames: extensionConfig.get("showMachineNames") || false,
     fullNamespace: extensionConfig.get("fullNamespace") || false,
+    briefCompletions: extensionConfig.get("briefCompletions") || false,
   };
   const clientOptions: LanguageClientOptions = {
     documentSelector: [


### PR DESCRIPTION
idris-community/idris2-lsp#197 adds a new configuration option to control the behavior of text completions in the LSP.   It allows users to choose to have tab completion with just the function name and no parens or argument placeholders. This PR adds the option to the vscode plugin and passes it to LSP.  If they choose to merge PR 197, we will need this one to make use of it.

This addresses #15, but needs PR 197 on the LSP side.