### PR TITLE
Highlight idris in markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	},
 	"activationEvents": [
 		"onLanguage:idris",
-		"onLanguage:lidr"
+		"onLanguage:lidr",
+		"workspaceContains:*.ipkg"
 	],
 	"main": "./out/main.js",
 	"contributes": {
@@ -158,6 +159,14 @@
 				"language": "lidr",
 				"scopeName": "source.idris.literate",
 				"path": "./syntaxes/lidr.tmLanguage.json"
+			},
+			{
+				"path": "./syntaxes/inject.json",
+				"scopeName": "idris.injection",
+				"injectTo": ["text.html.markdown"],
+				"embeddedLanguages": {
+					"meta.embedded.block.idris": "idris"
+				}
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export function activate(context: ExtensionContext) {
       detached: true // let us handle the disposal of the server
     });
   });
-  let initializationOptions = {
+  const initializationOptions = {
     logSeverity: extensionConfig.get("logSeverity") || "debug",
     logFile: extensionConfig.get("logFile") || "stderr",
     longActionTimeout: extensionConfig.get("longActionTimeout") || 5000,
@@ -61,6 +61,7 @@ export function activate(context: ExtensionContext) {
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
       { scheme: 'file', language: 'idris' },
+      { scheme: 'file', language: 'markdown', pattern: '**/*.{lidr,idr}.md' },
       { scheme: 'file', language: 'lidr' }
     ],
     initializationOptions: initializationOptions,

--- a/syntaxes/inject.json
+++ b/syntaxes/inject.json
@@ -1,0 +1,44 @@
+{
+    "scopeName": "idris.injection",
+	"injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#fenced_code_block_idris"
+        }
+    ],
+    "repository": {
+        "fenced_code_block_idris": {
+            "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(idris|idris2)((\\s+|:|,|\\{|\\?)[^`]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.idris",
+                    "patterns": [
+                        {
+                            "include": "source.idris"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR injects the `source.idris` into `idris` markdown code blocks in visual studio code. This will give us the base textmate highlighting and support for the comment commands within those code blocks everywhere.

Additionally, if the file has the extension `.idr.md` or `.lidr.md` and resides in a workspace with an `.ipkg` file, it is loaded in markdown mode, but the idris code blocks have full LSP support and semantic highlighting.

To get the markdown support, the file had to be `markdown` language, so I needed a criterion other than language to activate the extension. I chose to use the presence of an `.ipkg` in the root (and then the LSP can activate based on the extension).

